### PR TITLE
修复描边采样至屏幕外的bug

### DIFF
--- a/BuiltInAssets/Shaders/SilhouetteOutline.zxshader
+++ b/BuiltInAssets/Shaders/SilhouetteOutline.zxshader
@@ -57,10 +57,22 @@ Fragment
 
             float v0 = texture(_RenderTexture, TexCoords).r;
 
-            float v1 = texture(_RenderTexture, TexCoords + vec2( texOffset.x,  texOffset.y)).r;
-            v1 += texture(_RenderTexture, TexCoords + vec2( texOffset.x, -texOffset.y)).r;
-            v1 += texture(_RenderTexture, TexCoords + vec2(-texOffset.x,  texOffset.y)).r;
-            v1 += texture(_RenderTexture, TexCoords + vec2(-texOffset.x, -texOffset.y)).r;
+            float v1 = 0.0;
+            vec2 realTexPos = TexCoords + vec2( texOffset.x,  texOffset.y);
+            if ((realTexPos.x >= 0) && (realTexPos.x <= 1) && (realTexPos.y >= 0) && (realTexPos.y <= 1))
+                v1 += texture(_RenderTexture, realTexPos).r;
+
+            realTexPos = TexCoords + vec2( texOffset.x, -texOffset.y);
+            if ((realTexPos.x >= 0) && (realTexPos.x <= 1) && (realTexPos.y >= 0) && (realTexPos.y <= 1))
+                v1 += texture(_RenderTexture, realTexPos).r;
+
+            realTexPos = TexCoords + vec2(-texOffset.x,  texOffset.y);
+            if ((realTexPos.x >= 0) && (realTexPos.x <= 1) && (realTexPos.y >= 0) && (realTexPos.y <= 1))
+                v1 += texture(_RenderTexture, realTexPos).r;
+
+            realTexPos = TexCoords + vec2(-texOffset.x, -texOffset.y);
+            if ((realTexPos.x >= 0) && (realTexPos.x <= 1) && (realTexPos.y >= 0) && (realTexPos.y <= 1))
+                v1 += texture(_RenderTexture, realTexPos).r;
 
             if ((v0 < 0.5 && v1 > 0.5) || (v0 > 0.5 && v1 < 3.5))
                 FragColor = vec4(1.0, 0.5, 0.0, 1.0);


### PR DESCRIPTION
## 修复物体描边显示错误的bug

在`SilhouetteOutline.zxshader`中，选中物体时可能会在屏幕四周出现错误的描边显示。这是因为在纹理采样过程中，采样屏幕外的纹理导致的。这里为采样Offset增加了屏幕边界判断，防止出现上述错误情况。

修改前：
![930bd9bb82dcc44ebfeb85175c1346c7](https://github.com/user-attachments/assets/f6c604e9-33b8-4b9b-8bf2-82f9a89076c5)

修改后：
![bc2c3dcd255292fca36db2184ab2729c](https://github.com/user-attachments/assets/7e862c5b-9001-4b38-9d0b-4a9aefd65f88)

> Ps：感谢老哥的开源实现，拯救我本科毕设！
